### PR TITLE
docs: harden API credential guidance and add contributor templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in values from your OKX Developer account.
+# Never commit real credentials.
+
+OKX_API_KEY="your-api-key"
+OKX_SECRET_KEY="your-secret-key"
+OKX_PASSPHRASE="your-passphrase"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Type of Change
+
+- [ ] docs
+- [ ] fix
+- [ ] feat
+- [ ] chore
+
+## Checklist
+
+- [ ] No secrets/credentials added
+- [ ] Scope is focused and reviewable
+- [ ] Docs updated (if applicable)
+- [ ] Tests/checks run (if applicable)
+- [ ] No breaking change (or clearly documented)
+
+## Validation
+
+<!-- Commands run, screenshots, logs, or manual test notes -->
+
+## Follow-ups (optional)
+
+<!-- Any next-step work that is intentionally out of scope -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to onchainos-skills
+
+Thanks for contributing.
+
+## Ground Rules
+
+- Keep changes focused and reviewable.
+- Open an issue first for large or breaking changes.
+- Never commit API keys, private keys, or other secrets.
+
+## Local Workflow
+
+1. Fork the repo and create a branch:
+   - `docs/...` for docs-only
+   - `fix/...` for bug fixes
+   - `feat/...` for new features
+2. Make small, atomic commits.
+3. Run relevant checks for your change.
+4. Open a PR with clear scope and testing notes.
+
+## Commit Style (recommended)
+
+Use conventional commit style where possible:
+
+- `docs: ...`
+- `fix: ...`
+- `feat: ...`
+- `chore: ...`
+
+## Pull Request Checklist
+
+- [ ] Scope is small and clearly explained
+- [ ] No secrets or credentials introduced
+- [ ] Docs updated if behavior/usage changed
+- [ ] Backward compatibility considered
+- [ ] Screenshots/logs added when useful
+
+## Security
+
+If you discover a security issue, do **not** open a public issue with exploit details.
+Use private disclosure channels via OKX security/contact process.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 onchainos skills for AI coding assistants. Provides token search, market data, wallet balance queries, swap execution, and transaction broadcasting across 20+ blockchains.
 
+Contributing? See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## Available Skills
 
 | Skill | Description |
@@ -20,7 +22,13 @@ XLayer, Solana, Ethereum, Base, BSC, Arbitrum, Polygon, and 20+ other chains.
 
 All skills require OKX API credentials. Apply at [OKX Developer Portal](https://web3.okx.com/onchain-os/dev-portal).
 
-Recommended: create a `.env` file in your project root:
+Recommended: copy `.env.example` to `.env` in your project root and fill in your own credentials:
+
+```bash
+cp .env.example .env
+```
+
+Then update:
 
 ```bash
 OKX_API_KEY="your-api-key"
@@ -32,13 +40,15 @@ OKX_PASSPHRASE="your-passphrase"
 
 ### Quick Start — Try It Now
 
-Want to try the skills right away? Use the shared API key below:
+Want to try the skills right away? Use sandbox credentials from your own OKX Developer account.
 
 ```bash
-OKX_API_KEY="03f0b376-251c-4618-862e-ae92929e0416"
-OKX_SECRET_KEY="652ECE8FF13210065B0851FFDA9191F7"
-OKX_PASSPHRASE="onchainOS#666"
+OKX_API_KEY="your-sandbox-api-key"
+OKX_SECRET_KEY="your-sandbox-secret-key"
+OKX_PASSPHRASE="your-sandbox-passphrase"
 ```
+
+If you don't have sandbox credentials yet, apply in the [OKX Developer Portal](https://web3.okx.com/onchain-os/dev-portal).
 
 ## Installation
 
@@ -102,12 +112,12 @@ curl -sSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh
 
 ## API Key Security Notice & Disclaimer
 
-**Built-in Sandbox API Keys (Default)** This integration includes built-in sandbox API keys for testing purposes only. By using these keys, you acknowledge and accept the following:
+This integration does **not** ship with production credentials. For testing and production, use credentials issued to your own OKX Developer account.
 
-* These keys are shared and may be subject to rate limiting, quota exhaustion, or unexpected behavior at any time without prior notice.
-* Any Agent execution errors, failures, financial losses, or data inaccuracies arising from the use of built-in keys are solely your responsibility.
-* We expressly disclaim all liability for any direct, indirect, incidental, or consequential damages resulting from the use of built-in sandbox keys in production or quasi-production environments.
-* Built-in keys are strictly intended for local testing and evaluation only. Do not use them in production environments or with real assets.
+* Never commit API keys to source control.
+* Never expose keys in logs, screenshots, issue comments, or chat messages.
+* Use sandbox credentials only for testing and evaluation.
+* Use dedicated production credentials for real assets and production traffic.
 
 **Production Usage (Recommended)** For stable and reliable production usage, you must provide your own API credentials by setting the following environment variables:
 


### PR DESCRIPTION
## Summary
This PR improves contribution hygiene and credential safety in `onchainos-skills` without changing runtime behavior.

## What changed
- Replaced inline shared API credential examples in `README.md` with user-owned sandbox placeholders
- Added explicit guidance to copy `.env.example` to `.env`
- Added `CONTRIBUTING.md` with lightweight workflow and security expectations
- Added `.github/pull_request_template.md` to standardize PR quality checks
- Linked `CONTRIBUTING.md` from README

## Why
- Reduce risk of copy-pasting exposed credentials
- Improve onboarding for first-time contributors
- Make PRs easier to review with consistent checklist

## Scope / Risk
- Docs + templates only
- No code-path changes, no API behavior changes

## Follow-ups (out of scope)
- Capability matrix per chain/skill
- Examples directory for common workflows
- Optional CI secret scan stage