### PR TITLE
docs: add capability matrix and example workflow skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 onchainos skills for AI coding assistants. Provides token search, market data, wallet balance queries, swap execution, and transaction broadcasting across 20+ blockchains.
 
+Quick references:
+- Capability matrix: [docs/CAPABILITY_MATRIX.md](./docs/CAPABILITY_MATRIX.md)
+- Example workflows: [examples/](./examples/)
+
 ## Available Skills
 
 | Skill | Description |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -1,0 +1,53 @@
+# OnchainOS Skills Capability Matrix
+
+This matrix gives contributors and integrators a quick map of what each skill does and how to compose them.
+
+## Skill x Action Matrix
+
+| Skill | Discover | Market Data | Portfolio | Swap Quote | Swap Execute | Simulate | Broadcast | Order Tracking |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `okx-dex-token` | ✅ | ✅ (enriched analytics) | - | - | - | - | - | - |
+| `okx-dex-market` | ✅ (signals/meme scan) | ✅ (raw price/kline/trades/index) | - | - | - | - | - | - |
+| `okx-wallet-portfolio` | - | - | ✅ | - | - | - | - | - |
+| `okx-dex-swap` | - | - | - | ✅ | ✅ (tx data generation) | - | - | - |
+| `okx-onchain-gateway` | - | - | - | - | - | ✅ | ✅ | ✅ |
+
+## Chain Coverage Snapshot
+
+> Source: skill docs in `skills/*/SKILL.md` and project README.
+
+| Capability | Coverage |
+|---|---|
+| Token / Market / Portfolio / Swap / Gateway core flows | 20+ chains (including XLayer, Solana, Ethereum, Base, BSC, Arbitrum, Polygon) |
+| Smart-money signals (`market signal-*`) | Chain-dependent; discover via `onchainos market signal-chains` |
+| Meme pump endpoints (`market memepump-*`) | Solana (501), BSC (56), X Layer (196), TRON (195) |
+| `swap exactOut` mode | Ethereum (1), Base (8453), BSC (56), Arbitrum (42161) |
+
+## Recommended Workflow Patterns
+
+### 1) Research -> Trade
+1. `token search` / `token price-info`
+2. `market kline` / `market trades`
+3. `swap quote`
+4. `swap swap` (get tx data)
+5. Sign locally
+6. `gateway broadcast` -> `gateway orders`
+
+### 2) Portfolio-first Trading
+1. `portfolio all-balances`
+2. `token price-info` (top holdings)
+3. `swap quote` / `swap swap`
+4. Sign + `gateway broadcast`
+
+### 3) Safety-first Meme Flow
+1. `market memepump-tokens`
+2. `market memepump-token-details`
+3. `market memepump-token-dev-info`
+4. `market memepump-token-bundle-info`
+5. `swap quote` only after user confirmation
+
+## Notes for Contributors
+
+- Keep this matrix in sync with command references in `skills/*/SKILL.md`.
+- Prefer additive edits (new rows/columns) over rewrites.
+- If a capability is chain-limited, document discovery command + explicit exceptions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples (Skeleton)
+
+This folder provides minimal, reviewable workflow examples for common OnchainOS usage.
+
+- `portfolio-overview.md` — read-only balance + valuation flow
+- `swap-flow.md` — quote -> approve (if needed) -> swap -> broadcast
+- `simulate-broadcast.md` — simulate before broadcasting signed tx
+
+> Safety: examples use placeholders only. Never commit real API keys or private keys.

--- a/examples/portfolio-overview.md
+++ b/examples/portfolio-overview.md
@@ -1,0 +1,18 @@
+# Portfolio Overview (Read-only)
+
+## Goal
+Check total portfolio value and token balances across selected chains.
+
+## Commands
+
+```bash
+onchainos portfolio total-value --address <WALLET_ADDRESS> --chains "xlayer,solana,ethereum"
+onchainos portfolio all-balances --address <WALLET_ADDRESS> --chains "xlayer,solana,ethereum"
+```
+
+## Optional follow-up
+
+```bash
+onchainos token price-info <TOKEN_ADDRESS> --chain <CHAIN>
+onchainos market kline <TOKEN_ADDRESS> --chain <CHAIN> --bar 1H --limit 24
+```

--- a/examples/simulate-broadcast.md
+++ b/examples/simulate-broadcast.md
@@ -1,0 +1,23 @@
+# Simulate then Broadcast
+
+## Goal
+Reduce failed transactions by simulating before submit.
+
+## Commands
+
+1) Estimate gas / gas limit
+```bash
+onchainos gateway gas --chain <CHAIN>
+onchainos gateway gas-limit --from <FROM> --to <TO> --chain <CHAIN> --data <CALLDATA>
+```
+
+2) Simulate
+```bash
+onchainos gateway simulate --from <FROM> --to <TO> --data <CALLDATA> --chain <CHAIN>
+```
+
+3) If simulation passes, sign and broadcast
+```bash
+onchainos gateway broadcast --signed-tx <SIGNED_TX> --address <FROM> --chain <CHAIN>
+onchainos gateway orders --address <FROM> --chain <CHAIN>
+```

--- a/examples/swap-flow.md
+++ b/examples/swap-flow.md
@@ -1,0 +1,27 @@
+# Swap Flow (Quote -> Execute -> Broadcast)
+
+## Goal
+Perform a standard token swap with explicit confirmation points.
+
+## Commands
+
+1) Quote
+```bash
+onchainos swap quote --from <FROM_TOKEN> --to <TO_TOKEN> --amount <MINIMAL_UNITS> --chain <CHAIN>
+```
+
+2) Approve (EVM ERC-20 only)
+```bash
+onchainos swap approve --token <FROM_TOKEN> --amount <MINIMAL_UNITS> --chain <CHAIN>
+```
+
+3) Build swap tx
+```bash
+onchainos swap swap --from <FROM_TOKEN> --to <TO_TOKEN> --amount <MINIMAL_UNITS> --chain <CHAIN> --wallet <WALLET_ADDRESS> --slippage 1
+```
+
+4) Sign locally, then broadcast
+```bash
+onchainos gateway broadcast --signed-tx <SIGNED_TX> --address <WALLET_ADDRESS> --chain <CHAIN>
+onchainos gateway orders --address <WALLET_ADDRESS> --chain <CHAIN>
+```


### PR DESCRIPTION
## Summary
Add contributor-friendly docs that clarify skill boundaries and common flow composition.

## What changed
- Added `docs/CAPABILITY_MATRIX.md` with:
  - skill x action matrix
  - chain coverage snapshot
  - recommended workflow patterns
- Added `examples/` skeletons:
  - `portfolio-overview.md`
  - `swap-flow.md`
  - `simulate-broadcast.md`
  - `README.md`
- Added README quick links to matrix + examples

## Scope / Risk
- Docs only
- No runtime or API behavior changes

## Why
- Reduce integration ambiguity across skills
- Give first-time contributors copyable flow templates
- Make review and onboarding faster
