### PR TITLE
ci: add lightweight non-blocking secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,35 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: ["*"]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks (non-blocking)
+        id: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+          GITLEAKS_ENABLE_SUMMARY: true
+
+      - name: Upload SARIF if present
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Add a lightweight GitHub Actions secret scan job using gitleaks.

## What changed
- Added `.github/workflows/secret-scan.yml`
- Runs on push + pull_request
- Uses `gitleaks/gitleaks-action@v2`
- Configured as non-blocking (`continue-on-error: true`)
- Attempts SARIF upload when report exists

## Why
- Catch accidentally committed credentials early
- Improve repo security posture with minimal maintainer friction

## Scope / Risk
- CI-only change
- No runtime behavior changes
- Non-blocking by design for gradual adoption